### PR TITLE
Change method to retrieve group name from annotation

### DIFF
--- a/reportng/pom.xml
+++ b/reportng/pom.xml
@@ -5,7 +5,7 @@
   <name>ReportNG</name>
   <groupId>org.uncommons</groupId>
   <artifactId>reportng</artifactId>
-  <version> 1.1.9-SNAPSHOT</version>
+  <version>1.1.9-SNAPSHOT</version>
   <packaging>jar</packaging>
   <url>https://reportng.dev.java.net/</url>
 
@@ -50,6 +50,16 @@
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>2.5.1</version>
+                <inherited>true</inherited>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>

--- a/reportng/src/java/main/org/uncommons/reportng/ReportNGUtils.java
+++ b/reportng/src/java/main/org/uncommons/reportng/ReportNGUtils.java
@@ -573,4 +573,18 @@ public class ReportNGUtils {
         }
         return specificTestFixedDefects;
     }
+
+    /**
+     * Returns in case of Appium running tests the name of the mobile device that the test has run
+     * @param context
+     * @return
+     */
+    public String getMobileDevice(ITestContext context) {
+        Object deviceName = context.getAttribute("mobileDevice");
+        if (deviceName != null) {
+            return (String) deviceName;
+        } else {
+            return "";
+        }
+    }
 }

--- a/reportng/src/java/main/org/uncommons/reportng/ReportNGUtils.java
+++ b/reportng/src/java/main/org/uncommons/reportng/ReportNGUtils.java
@@ -419,7 +419,7 @@ public class ReportNGUtils {
             for (ITestNGMethod testMethod : testMethods) {
                 for (String group : groups) {
                     List<ISuiteResult> resultsForGroup = new ArrayList<ISuiteResult>();
-                    if (getTestClassGroup(testMethod.getTestClass()).contains(group)) {
+                    if (getTestClassGroup(testMethod.getTestClass()).equals(group)) {
                         resultsForGroup.add(result);
                         if (resultsByGroup.get(group) != null) {
                             resultsForGroup.addAll(resultsByGroup.get(group));
@@ -464,7 +464,8 @@ public class ReportNGUtils {
         Optional<Annotation> groupAnnotation = Arrays.stream(annotations).filter(annotation -> annotation.annotationType().getName().endsWith(".Group")).findFirst();
         if (groupAnnotation.isPresent()) {
             Method name = Class.forName(groupAnnotation.get().annotationType().getName()).getMethod("name");
-            group = ((String[])name.invoke(groupAnnotation.get()))[0];
+            Object annotationValue = name.invoke(groupAnnotation.get());
+            group = annotationValue instanceof String[] ? ((String[]) annotationValue)[0] : (String) annotationValue;
         }
         return group;
     }

--- a/reportng/src/java/resources/org/uncommons/reportng/templates/html/results.html.vm
+++ b/reportng/src/java/resources/org/uncommons/reportng/templates/html/results.html.vm
@@ -14,7 +14,7 @@
 </head>
 <body>
 <h1>$result.testContext.name</h1>
-
+<h2>$utils.getMobileDevice($result.testContext)</h2>
 <p>
     $messages.getString("testDuration"): $utils.formatDuration($utils.getDuration($result.testContext))
 </p>


### PR DESCRIPTION
Change method to retrieve Group annotation value.
This code is compatible with Java 8 as well.
Since Java streams were used the minimum version supported in pom.xml is Java 1.8.