### PR TITLE
Fix reportng generation

### DIFF
--- a/reportng/pom.xml
+++ b/reportng/pom.xml
@@ -5,7 +5,7 @@
   <name>ReportNG</name>
   <groupId>org.uncommons</groupId>
   <artifactId>reportng</artifactId>
-  <version> 1.2.0</version>
+  <version> 1.2.1-SNAPSHOT</version>
   <packaging>jar</packaging>
   <url>https://reportng.dev.java.net/</url>
 
@@ -32,7 +32,7 @@
 
     <scm>
         <developerConnection>scm:git:git@github.com:Workable/reportng.git</developerConnection>
-        <tag>reportng-1.2.0</tag>
+        <tag>reportng-1.1.6</tag>
     </scm>
 
   <dependencies>

--- a/reportng/pom.xml
+++ b/reportng/pom.xml
@@ -5,7 +5,7 @@
   <name>ReportNG</name>
   <groupId>org.uncommons</groupId>
   <artifactId>reportng</artifactId>
-  <version> 1.1.9-SNAPSHOT</version>
+  <version> 1.2.0</version>
   <packaging>jar</packaging>
   <url>https://reportng.dev.java.net/</url>
 
@@ -32,7 +32,7 @@
 
     <scm>
         <developerConnection>scm:git:git@github.com:Workable/reportng.git</developerConnection>
-        <tag>reportng-1.1.6</tag>
+        <tag>reportng-1.2.0</tag>
     </scm>
 
   <dependencies>

--- a/reportng/pom.xml
+++ b/reportng/pom.xml
@@ -31,7 +31,7 @@
     </distributionManagement>
 
     <scm>
-        <developerConnection>scm:git:https://github.com/Workable/reportng.git</developerConnection>
+        <developerConnection>scm:git:git@github.com:Workable/reportng.git</developerConnection>
         <tag>reportng-1.1.6</tag>
     </scm>
 

--- a/reportng/src/java/main/org/uncommons/reportng/ReportNGUtils.java
+++ b/reportng/src/java/main/org/uncommons/reportng/ReportNGUtils.java
@@ -417,7 +417,7 @@ public class ReportNGUtils {
             for (ITestNGMethod testMethod : testMethods) {
                 for (String group : groups) {
                     List<ISuiteResult> resultsForGroup = new ArrayList<ISuiteResult>();
-                    if (getTestClassGroup(testMethod.getTestClass()).contains(group)) {
+                    if (getTestClassGroup(testMethod.getTestClass()).equals(group)) {
                         resultsForGroup.add(result);
                         if (resultsByGroup.get(group) != null) {
                             resultsForGroup.addAll(resultsByGroup.get(group));


### PR DESCRIPTION
We have multiple cases where the reportng report is not being generated, by changing the contains to equals the issue is resolved. The reason is because some test groups may be supersets of others and upon assignment of a test case to a test group reportNg may try to assign a test case to wrong group.